### PR TITLE
Fixed ReplyTo to use display name and email

### DIFF
--- a/lib/mailjet/mailer.rb
+++ b/lib/mailjet/mailer.rb
@@ -119,8 +119,8 @@ class Mailjet::APIMailer
     # ReplyTo property was added in v3.1
     # Passing it as an header if mail.reply_to
 
-    if mail.reply_to
-      if mail.reply_to.respond_to?(:display_names) && mail.reply_to.display_names.first
+    if mail[:reply_to]
+      if mail[:reply_to].respond_to?(:display_names) && mail[:reply_to].display_names.first
         content[:ReplyTo] = {:Email=> mail[:reply_to].addresses.first, :Name=> mail[:reply_to].display_names.first}
       else
         content[:ReplyTo] = {:Email=> mail[:reply_to].addresses.first}


### PR DESCRIPTION
ReplyTo field was working but without the display name used in the ActionMailer object